### PR TITLE
Add `docker` to the container

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -41,8 +41,9 @@ RUN ARCH=$(dpkg --print-architecture) && \
     chmod +x /usr/local/bin/hadolint
 
 # Install Docker CLI
+# hadolint ignore=DL3008,SC1091
 RUN install -m 0755 -d /etc/apt/keyrings && \
-    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+    wget -q https://download.docker.com/linux/debian/gpg -O /etc/apt/keyrings/docker.asc && \
     chmod a+r /etc/apt/keyrings/docker.asc && \
     echo \
     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -40,8 +40,21 @@ RUN ARCH=$(dpkg --print-architecture) && \
     fi && \
     chmod +x /usr/local/bin/hadolint
 
+# Install Docker CLI
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc && \
+    echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+    tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get -y --no-install-recommends install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists
+
 # Create a non-root user and group
-RUN useradd --home-dir /home/developer --create-home --skel /etc/skel --shell /bin/bash --uid 1001 developer
+RUN useradd --home-dir /home/developer --create-home --skel /etc/skel --shell /bin/bash --uid 1001 developer --groups docker
 
 # Set the working directory for the new user
 WORKDIR /home/developer

--- a/src/bash/bashrc
+++ b/src/bash/bashrc
@@ -19,6 +19,7 @@ export PROMPT_COMMAND=
 alias ls='ls -h --color'
 alias ll='ls -alF'
 alias la='ls -l'
+alias docker='sudo docker'
 #-------------------------------------------------------------------------------
 # Run any local .bashrc files
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This way, we can build images inside of the Docker container itself. I also wanted it to be able to run images too, but that was a bit harder. To do it, you either have to do a Docker in Docker, which is not recommended, or mount the `docker.sock` file into the container at the correct location (which is `/var/run/docker`). But the latter had the issue that is was mounted with the wrong group ownership. It is mounted with the group ownership of the host, which in my case is GID 139. The docker group in the container, however, is GID 999. This conflict and therefor, the default developer user couldn't run Docker commands. I could, ofcourse, change the GID inside the coutainer to 139, but that would remove all portability.

Instead, I choose to add a alias for `docker` in the `.bashrc` file. This alias simply runs `sudo docker`, which makes it work again. It might not be ideal but it works.

Fixes #26